### PR TITLE
disable spectator PH and TW on MainPage

### DIFF
--- a/LegendaryClient/App.xaml
+++ b/LegendaryClient/App.xaml
@@ -124,11 +124,12 @@
             <sys:String>LAN</sys:String>
             <sys:String>TR</sys:String>
             <sys:String>CS</sys:String>
-            <sys:String>PH</sys:String>
+            <!-- <sys:String>PH
+                </sys:String> -->
             <sys:String>SG</sys:String>
             <sys:String>SGMY</sys:String>
             <sys:String>TH</sys:String>
-            <sys:String>TW</sys:String>
+           <!-- <sys:String>TW</sys:String> -->
             <sys:String>VN</sys:String>
             <sys:String>ID</sys:String>
         </x:Array>


### PR DESCRIPTION
disable spectator PH and TW on MainPage
Because haven't featured url and spectator ip
